### PR TITLE
Enable building KWasm in `--coverage` mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /.build
 /tests/*.out
+/__pycache__

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,2 @@
 /.build
 /tests/*.out
-
-/rustc-*

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -54,6 +54,13 @@ pipeline {
     }
     stage('Test') {
       parallel {
+        stage('Can Build loaded') {
+          steps {
+            sh '''
+              make polkadot-runtime-loaded
+            '''
+          }
+        }
         stage('Can Build Specs') {
           steps {
             sh '''

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -61,6 +61,13 @@ pipeline {
             '''
           }
         }
+        stage('Python Config') {
+          steps {
+            sh '''
+              make test-python-config
+            '''
+          }
+        }
       }
     }
   }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -54,13 +54,6 @@ pipeline {
     }
     stage('Test') {
       parallel {
-        stage('Can Build loaded') {
-          steps {
-            sh '''
-              make polkadot-runtime-loaded
-            '''
-          }
-        }
         stage('Can Build Specs') {
           steps {
             sh '''

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 
-.PHONY: clean distclean deps deps-polkadot                      \
-        build build-coverage-llvm polkadot-runtime-source specs \
+.PHONY: clean distclean deps deps-polkadot              \
+        build build-coverage-llvm specs                 \
+        polkadot-runtime-source polkadot-runtime-loaded \
         test test-can-build-specs test-python-config
 
 # Settings
@@ -85,7 +86,8 @@ $(DEFN_DIR)/kwasm/llvm/%.k: %.md $(TANGLER)
 CONCRETE_BACKEND := llvm
 SYMBOLIC_BACKEND := haskell
 
-polkadot-runtime-source: src/polkadot-runtime.loaded.json
+polkadot-runtime-source: src/polkadot-runtime.wat
+polkadot-runtime-loaded: src/polkadot-runtime.loaded.json
 
 src/polkadot-runtime.loaded.json: src/polkadot-runtime.wat.json
 	./kpol run --backend $(CONCRETE_BACKEND) $< --parser cat --output json > $@

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ distclean: clean
 	rm -rf $(BUILD_DIR)
 
 deps:
-	git submodule update --init --recursive
+	git submodule update --init --recursive -- $(K_SUBMODULE)
 	$(KWASM_MAKE) deps
 
 # Polkadot Setup

--- a/Makefile
+++ b/Makefile
@@ -63,8 +63,18 @@ build: build-kwasm-java build-kwasm-haskell build-kwasm-llvm build-kwasm-ocaml
 # Regular Semantics Build
 # -----------------------
 
-build-kwasm-%:
-	$(KWASM_MAKE) build-$* DEFN_DIR=../../$(BUILD_DIR)/defn/kwasm
+build-kwasm-%: $(DEFN_DIR)/kwasm/%/wasm-with-k-term.k
+	$(KWASM_MAKE) build-$*                         \
+	    DEFN_DIR=../../$(DEFN_DIR)/kwasm           \
+	    MAIN_MODULE=WASM-WITH-K-TERM               \
+	    MAIN_SYNTAX_MODULE=WASM-WITH-K-TERM-SYNTAX \
+	    MAIN_DEFN_FILE=wasm-with-k-term.k
+
+.SECONDARY: $(DEFN_DIR)/kwasm/llvm/wasm-with-k-term.k
+
+$(DEFN_DIR)/kwasm/llvm/%.k: %.md $(TANGLER)
+	@mkdir -p $(dir $@)
+	pandoc --from markdown --to $(TANGLER) --metadata=code:".k" $< > $@
 
 # Verification Source Build
 # -------------------------

--- a/Makefile
+++ b/Makefile
@@ -74,9 +74,14 @@ build-kwasm-%: $(DEFN_DIR)/kwasm/%/wasm-with-k-term.k
 	    MAIN_DEFN_FILE=wasm-with-k-term            \
 	    KOMPILE_OPTIONS=$(KOMPILE_OPTIONS)
 
-.SECONDARY: $(DEFN_DIR)/kwasm/llvm/wasm-with-k-term.k
+.SECONDARY: $(DEFN_DIR)/kwasm/llvm/wasm-with-k-term.k    \
+            $(DEFN_DIR)/kwasm/haskell/wasm-with-k-term.k
 
 $(DEFN_DIR)/kwasm/llvm/%.k: %.md $(TANGLER)
+	@mkdir -p $(dir $@)
+	pandoc --from markdown --to $(TANGLER) --metadata=code:".k" $< > $@
+
+$(DEFN_DIR)/kwasm/haskell/%.k: %.md $(TANGLER)
 	@mkdir -p $(dir $@)
 	pandoc --from markdown --to $(TANGLER) --metadata=code:".k" $< > $@
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 
-.PHONY: clean distclean deps deps-polkadot           \
-        build polkadot-runtime-source specs          \
+.PHONY: clean distclean deps deps-polkadot                      \
+        build build-coverage-llvm polkadot-runtime-source specs \
         test test-can-build-specs test-python-config
 
 # Settings
@@ -58,7 +58,9 @@ deps-polkadot:
 # Useful Builds
 # -------------
 
-build: build-kwasm-java build-kwasm-haskell build-kwasm-llvm build-kwasm-ocaml
+KOMPILE_OPTIONS :=
+
+build: build-kwasm-haskell build-kwasm-llvm build-coverage-llvm
 
 # Regular Semantics Build
 # -----------------------
@@ -68,7 +70,8 @@ build-kwasm-%: $(DEFN_DIR)/kwasm/%/wasm-with-k-term.k
 	    DEFN_DIR=../../$(DEFN_DIR)/kwasm           \
 	    MAIN_MODULE=WASM-WITH-K-TERM               \
 	    MAIN_SYNTAX_MODULE=WASM-WITH-K-TERM-SYNTAX \
-	    MAIN_DEFN_FILE=wasm-with-k-term.k
+	    MAIN_DEFN_FILE=wasm-with-k-term            \
+	    KOMPILE_OPTIONS=$(KOMPILE_OPTIONS)
 
 .SECONDARY: $(DEFN_DIR)/kwasm/llvm/wasm-with-k-term.k
 
@@ -96,6 +99,12 @@ src/polkadot-runtime.wat: $(POLKADOT_RUNTIME_WASM)
 $(POLKADOT_RUNTIME_WASM):
 	git submodule update --init --recursive -- $(POLKADOT_SUBMODULE)
 	cd $(POLKADOT_SUBMODULE) && cargo build --package node-template --release
+
+# Generate Execution Traces
+# -------------------------
+
+build-coverage-llvm: KOMPILE_OPTIONS+=--coverage
+build-coverage-llvm: build-kwasm-llvm
 
 # Specification Build
 # -------------------

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ distclean: clean
 	rm -rf $(BUILD_DIR)
 
 deps:
-	git submodule update --init --recursive -- $(K_SUBMODULE)
+	git submodule update --init --recursive -- $(KWASM_SUBMODULE)
 	$(KWASM_MAKE) deps
 
 # Polkadot Setup

--- a/README.md
+++ b/README.md
@@ -14,12 +14,6 @@ Polkadot Module Verification
 
 Make sure you have all the dependencies of KWasm installed: <https://github.com/kframework/wasm-semantics>.
 
-If you don't have `rustup`, get it with (likely if you've used other K projects or worked on Substrate you already have it):
-
-```sh
-curl https://sh.rustup.rs -sSf | sh -s -- -y
-```
-
 Then the following (roughly) is what you need to do to build KWasm for this repository.
 
 ```sh

--- a/pykWasm.py
+++ b/pykWasm.py
@@ -15,8 +15,7 @@ from pyk.kast import KApply, KConstant, KSequence, KToken, KVariable, _notif, _w
 # First strips the module name suffix off the label.
 underbarUnparsingInModule = lambda modName, inputString: pyk.underbarUnparsing(inputString.split('_' + modName)[0])
 
-WASM_symbols = { '.List{"___WASM__Stmt_Stmts"}_Stmts'                      : pyk.constLabel('.Stmts')
-               , '.ValStack_WASM-DATA_'                                    : pyk.constLabel('.ValStack')
+WASM_symbols = { '.ValStack_WASM-DATA_'                                    : pyk.constLabel('.ValStack')
                , '.Int_WASM-DATA_'                                         : pyk.constLabel('.Int')
                , '.ModuleInstCellMap'                                      : pyk.constLabel('.ModuleInstCellMap')
                , '.FuncDefCellMap'                                         : pyk.constLabel('.FuncDefCellMap')
@@ -27,6 +26,7 @@ WASM_symbols = { '.List{"___WASM__Stmt_Stmts"}_Stmts'                      : pyk
                , '___WASM__Stmt_Stmts'                                     : (lambda a1, a2: a1 + '\n' + a2)
                , '___WASM__Defn_Defns'                                     : (lambda a1, a2: a1 + '\n' + a2)
                , '___WASM__Instr_Instrs'                                   : (lambda a1, a2: a1 + '\n' + a2)
+               , '.List{"___WASM__Stmt_Stmts"}_Stmts'                      : pyk.constLabel('')
                , '.List{"___WASM__EmptyStmt_EmptyStmts"}_EmptyStmts'       : pyk.constLabel('')
                , '.List{"___WASM-DATA__ValType_ValTypes"}_ValTypes'        : pyk.constLabel('')
                , '.List{"___WASM__TypeDecl_TypeDecls"}_TypeDecls'          : pyk.constLabel('')

--- a/pykWasm.py
+++ b/pykWasm.py
@@ -121,11 +121,13 @@ def split_symbolic_config_from(configuration):
 # Main Functionality                                                           #
 ################################################################################
 
-init_term = { 'format': 'KAST', 'version': 1, 'term': KConstant('.List{"___WASM__Stmt_Stmts"}_Stmts') }
-(_, simple_config, _) = krun(init_term, '--parser', 'cat')
-(generatedTop, initSubst) = split_symbolic_config_from(simple_config)
+def get_init_config():
+    init_term = { 'format': 'KAST', 'version': 1, 'term': KConstant('.List{"___WASM__Stmt_Stmts"}_Stmts') }
+    (_, simple_config, _) = krun(init_term, '--parser', 'cat')
+    return split_symbolic_config_from(simple_config)
 
 if __name__ == '__main__':
+    (generatedTop, initSubst) = get_init_config()
     initial_configuration = pyk.substitute(generatedTop, initSubst)
     kast_json = { 'format': 'KAST', 'version': 1, 'term': initial_configuration }
 

--- a/pykWasm.py
+++ b/pykWasm.py
@@ -232,7 +232,7 @@ def split_symbolic_config_from(configuration):
 
 def get_init_config():
     init_term = { 'format': 'KAST', 'version': 1, 'term': KConstant('.List{"___WASM__Stmt_Stmts"}_Stmts') }
-    (_, simple_config, _) = krun(init_term, '--parser', 'cat')
+    (_, simple_config, _) = krun(init_term)
     return split_symbolic_config_from(simple_config)
 
 if __name__ == '__main__':

--- a/pykWasm.py
+++ b/pykWasm.py
@@ -15,24 +15,27 @@ from pyk.kast import KApply, KConstant, KSequence, KToken, KVariable, _notif, _w
 # First strips the module name suffix off the label.
 underbarUnparsingInModule = lambda modName, inputString: pyk.underbarUnparsing(inputString.split('_' + modName)[0])
 
-WASM_symbols = { '.List{"___WASM__Stmt_Stmts"}_Stmts'                 : pyk.constLabel('.Stmts')
-               , '.ValStack_WASM-DATA_'                               : pyk.constLabel('.ValStack')
-               , '.Int_WASM-DATA_'                                    : pyk.constLabel('.Int')
-               , '.ModuleInstCellMap'                                 : pyk.constLabel('.ModuleInstCellMap')
-               , '.FuncDefCellMap'                                    : pyk.constLabel('.FuncDefCellMap')
-               , '.TabInstCellMap'                                    : pyk.constLabel('.TabInstCellMap')
-               , '.MemInstCellMap'                                    : pyk.constLabel('.MemInstCellMap')
-               , '.GlobalInstCellMap'                                 : pyk.constLabel('.GlobalInstCellMap')
-               , 'ModuleInstCellMapItem'                              : (lambda a1, a2: a2)
-               , '___WASM__Stmt_Stmts'                                : (lambda a1, a2: a1 + '\n' + a2)
-               , '___WASM__Defn_Defns'                                : (lambda a1, a2: a1 + '\n' + a2)
-               , '___WASM__Instr_Instrs'                              : (lambda a1, a2: a1 + '\n' + a2)
-               , '.List{"___WASM__EmptyStmt_EmptyStmts"}_EmptyStmts'  : pyk.constLabel('')
-               , '.List{"___WASM-DATA__ValType_ValTypes"}_ValTypes'   : pyk.constLabel('')
-               , '.List{"___WASM__TypeDecl_TypeDecls"}_TypeDecls'     : pyk.constLabel('')
-               , '(module__)_WASM__OptionalId_Defns'                  : (lambda mName, mDefns: '(module ' + mName + '\n' + pyk.indent(mDefns) + '\n)')
-               , '(func__)_WASM__OptionalId_FuncSpec'                 : (lambda funcName, funcSpec: '(func ' + funcName + '\n' + pyk.indent(funcSpec) + '\n)')
-               , '____WASM__TypeUse_LocalDecls_Instrs'                : (lambda type, locals, instrs: '\n'.join([type, locals, instrs]))
+WASM_symbols = { '.List{"___WASM__Stmt_Stmts"}_Stmts'                      : pyk.constLabel('.Stmts')
+               , '.ValStack_WASM-DATA_'                                    : pyk.constLabel('.ValStack')
+               , '.Int_WASM-DATA_'                                         : pyk.constLabel('.Int')
+               , '.ModuleInstCellMap'                                      : pyk.constLabel('.ModuleInstCellMap')
+               , '.FuncDefCellMap'                                         : pyk.constLabel('.FuncDefCellMap')
+               , '.TabInstCellMap'                                         : pyk.constLabel('.TabInstCellMap')
+               , '.MemInstCellMap'                                         : pyk.constLabel('.MemInstCellMap')
+               , '.GlobalInstCellMap'                                      : pyk.constLabel('.GlobalInstCellMap')
+               , 'ModuleInstCellMapItem'                                   : (lambda a1, a2: a2)
+               , '___WASM__Stmt_Stmts'                                     : (lambda a1, a2: a1 + '\n' + a2)
+               , '___WASM__Defn_Defns'                                     : (lambda a1, a2: a1 + '\n' + a2)
+               , '___WASM__Instr_Instrs'                                   : (lambda a1, a2: a1 + '\n' + a2)
+               , '.List{"___WASM__EmptyStmt_EmptyStmts"}_EmptyStmts'       : pyk.constLabel('')
+               , '.List{"___WASM-DATA__ValType_ValTypes"}_ValTypes'        : pyk.constLabel('')
+               , '.List{"___WASM__TypeDecl_TypeDecls"}_TypeDecls'          : pyk.constLabel('')
+               , '.List{"___WASM__LocalDecl_LocalDecls"}_LocalDecls'       : pyk.constLabel('')
+               , '.List{"___WASM-DATA__Index_ElemSegment"}_ElemSegment'    : pyk.constLabel('')
+               , '.List{"___WASM-DATA__WasmString_DataString"}_DataString' : pyk.constLabel('')
+               , '(module__)_WASM__OptionalId_Defns'                       : (lambda mName, mDefns: '(module ' + mName + '\n' + pyk.indent(mDefns) + '\n)')
+               , '(func__)_WASM__OptionalId_FuncSpec'                      : (lambda funcName, funcSpec: '(func ' + funcName + '\n' + pyk.indent(funcSpec) + '\n)')
+               , '____WASM__TypeUse_LocalDecls_Instrs'                     : (lambda type, locals, instrs: '\n'.join([type, locals, instrs]))
                }
 
 WASM_DATA_underbar_unparsed_symbols = [ 'func_WASM-DATA_'
@@ -41,10 +44,57 @@ WASM_DATA_underbar_unparsed_symbols = [ 'func_WASM-DATA_'
                                       , 'i64_WASM-DATA_'
                                       , 'f32_WASM-DATA_'
                                       , 'f64_WASM-DATA_'
+                                      , '___WASM-DATA__Index_ElemSegment'
+                                      , '___WASM-DATA__Int_Int'
+                                      , '___WASM-DATA__WasmString_DataString'
+                                      , 'global_WASM-DATA_'
+                                      , 'memory_WASM-DATA_'
+                                      , 'table_WASM-DATA_'
                                       ]
 
 for symb in WASM_DATA_underbar_unparsed_symbols:
     WASM_symbols[symb] = underbarUnparsingInModule('WASM-DATA', symb)
+
+WASM_NUMERIC_underbar_unparsed_symbols = [ 'sub_WASM-NUMERIC_'
+                                         , 'eqz_WASM-NUMERIC_'
+                                         , 'add_WASM-NUMERIC_'
+                                         , 'and_WASM-NUMERIC_'
+                                         , 'eq_WASM-NUMERIC_'
+                                         , 'ne_WASM-NUMERIC_'
+                                         , 'extend_i32_u_WASM-NUMERIC_'
+                                         , 'div_u_WASM-NUMERIC_'
+                                         , 'gt_u_WASM-NUMERIC_'
+                                         , 'le_s_WASM-NUMERIC_'
+                                         , 'lt_s_WASM-NUMERIC_'
+                                         , 'lt_u_WASM-NUMERIC_'
+                                         , 'mul_WASM-NUMERIC_'
+                                         , 'shl_WASM-NUMERIC_'
+                                         , 'mul_WASM-NUMERIC_'
+                                         , 'shr_u_WASM-NUMERIC_'
+                                         , 'wrap_i64_WASM-NUMERIC_'
+                                         , 'or_WASM-NUMERIC_'
+                                         , 'ge_s_WASM-NUMERIC_'
+                                         , 'ge_u_WASM-NUMERIC_'
+                                         , 'gt_s_WASM-NUMERIC_'
+                                         , 'le_u_WASM-NUMERIC_'
+                                         , 'rem_s_WASM-NUMERIC_'
+                                         , 'rem_u_WASM-NUMERIC_'
+                                         , 'shr_s_WASM-NUMERIC_'
+                                         , 'xor_WASM-NUMERIC_'
+                                         , 'clz_WASM-NUMERIC_'
+                                         , 'ctz_WASM-NUMERIC_'
+                                         , 'div_s_WASM-NUMERIC_'
+                                         , 'ge_u_WASM-NUMERIC_'
+                                         , 'gt_s_WASM-NUMERIC_'
+                                         , 'le_u_WASM-NUMERIC_'
+                                         , 'popcnt_WASM-NUMERIC_'
+                                         , 'rem_u_WASM-NUMERIC_'
+                                         , 'shr_s_WASM-NUMERIC_'
+                                         , 'xor_WASM-NUMERIC_'
+                                         ]
+
+for symb in WASM_NUMERIC_underbar_unparsed_symbols:
+    WASM_symbols[symb] = underbarUnparsingInModule('WASM-NUMERIC', symb)
 
 WASM_underbar_unparsed_symbols = [ '(import___)_WASM__WasmString_WasmString_ImportDesc'
                                  , '(func__)_WASM__OptionalId_TypeUse'
@@ -59,6 +109,63 @@ WASM_underbar_unparsed_symbols = [ '(import___)_WASM__WasmString_WasmString_Impo
                                  , 'result_WASM_'
                                  , '(invoke_)_WASM__Int'
                                  , '_.const__WASM__IValType_Int'
+                                 , 'call__WASM__Index'
+                                 , 'unreachable_WASM_'
+                                 , '(type_)__WASM__Index_TypeDecls'
+                                 , '___WASM__LocalDecl_LocalDecls'
+                                 , 'local__WASM__ValTypes'
+                                 , 'global.get__WASM__Index'
+                                 , 'global.set__WASM__Index'
+                                 , 'local.tee__WASM__Index'
+                                 , 'local.set__WASM__Index'
+                                 , 'local.get__WASM__Index'
+                                 , '_.__WASM__IValType_IBinOp'
+                                 , 'block__end_WASM__TypeDecls_Instrs'
+                                 , '_.__WASM__IValType_TestOp'
+                                 , 'br_if__WASM__Index'
+                                 , '_.__WASM__IValType_LoadOpM'
+                                 , '_.__WASM__IValType_StoreOpM'
+                                 , '___WASM__LoadOp_MemArg'
+                                 , '___WASM__StoreOp_MemArg'
+                                 , 'load_WASM_'
+                                 , 'store_WASM_'
+                                 , '___WASM__OffsetArg_AlignArg'
+                                 , 'align=__WASM__Int'
+                                 , 'offset=__WASM__Int'
+                                 , 'br__WASM__Index'
+                                 , 'i32 . store8_WASM_'
+                                 , 'load8_u_WASM_'
+                                 , 'loop__end_WASM__TypeDecls_Instrs'
+                                 , 'return_WASM_'
+                                 , 'store8_WASM_'
+                                 , '_.__WASM__IValType_IRelOp'
+                                 , 'br_table__WASM__ElemSegment'
+                                 , 'select_WASM_'
+                                 , '_.__WASM__AValType_CvtOp'
+                                 , '_.__WASM__IValType_IUnOp'
+                                 , 'call_indirect__WASM__TypeUse'
+                                 , '(data__)_WASM__Offset_DataString'
+                                 , 'drop_WASM_'
+                                 , '(elem__)_WASM__Offset_ElemSegment'
+                                 , 'funcref_WASM_'
+                                 , '(global__)_WASM__OptionalId_GlobalSpec'
+                                 , 'i32 . load16_u_WASM_'
+                                 , 'i32 . load8_s_WASM_'
+                                 , 'i32 . store16_WASM_'
+                                 , 'i64 . load16_u_WASM_'
+                                 , 'i64 . load32_u_WASM_'
+                                 , 'i64 . store16_WASM_'
+                                 , 'i64 . store32_WASM_'
+                                 , '(memory__)_WASM__OptionalId_MemorySpec'
+                                 , '(mut_)_WASM__AValType'
+                                 , '(table__)_WASM__OptionalId_TableSpec'
+                                 , '___WASM__Limits_TableElemType'
+                                 , '___WASM__TextFormatGlobalType_Instr'
+                                 , 'load16_u_WASM_'
+                                 , 'load32_u_WASM_'
+                                 , 'load8_s_WASM_'
+                                 , 'store16_WASM_'
+                                 , 'store32_WASM_'
                                  ]
 
 for symb in WASM_underbar_unparsed_symbols:
@@ -71,6 +178,8 @@ for symb in WASM_TEST_underbar_unparsed_symbols:
     WASM_symbols[symb] = underbarUnparsingInModule('WASM-TEST', symb)
 
 WASM_TEXT_underbar_unparsed_symbols = [ '(_)_WASM-TEXT__PlainInstr'
+                                      , '___WASM-TEXT__InlineExport_FuncSpec'
+                                      , '(export_)_WASM-TEXT__WasmString'
                                       ]
 
 for symb in WASM_TEXT_underbar_unparsed_symbols:

--- a/pykWasm.py
+++ b/pykWasm.py
@@ -201,13 +201,38 @@ def kprove(inputJson, *krunArgs):
     return pyk.kproveJSON('.build/defn/kwasm/llvm', inputJson, kproveArgs = list(kproveArgs), kRelease = 'deps/wasm-semantics/deps/k/k-distribution/target/release/k')
 
 ################################################################################
+# Should be upstreamed into pyk                                                #
+################################################################################
+
+def splitConfigFrom(configuration):
+    """Split the substitution from a given configuration.
+
+    Given an input configuration `config`, will return a tuple `(symbolic_config, subst)`, where:
+
+        1.  `config == substitute(symbolic_config, subst)`
+        2.  `symbolic_config` is the same configuration structure, but where the contents of leaf cells is replaced with a fresh KVariable.
+        3.  `subst` is the substitution for the generated KVariables back to the original configuration contents.
+    """
+    initial_substitution = {}
+    _mkCellVar = lambda label: label.replace('-', '_').replace('<', '').replace('>', '').upper() + '_CELL'
+    def _replaceWithVar(k):
+        if pyk.isKApply(k) and pyk.isCellKLabel(k['label']):
+            if len(k['args']) == 1 and not (pyk.isKApply(k['args'][0]) and pyk.isCellKLabel(k['args'][0]['label'])):
+                config_var = _mkCellVar(k['label'])
+                initial_substitution[config_var] = k['args'][0]
+                return KApply(k['label'], [KVariable(config_var)])
+        return k
+    symbolic_config = pyk.traverseBottomUp(configuration, _replaceWithVar)
+    return (symbolic_config, initial_substitution)
+
+################################################################################
 # Main Functionality                                                           #
 ################################################################################
 
 def get_init_config():
     init_term = { 'format': 'KAST', 'version': 1, 'term': KConstant('.List{"___WASM__Stmt_Stmts"}_Stmts') }
     (_, simple_config, _) = krun(init_term)
-    return pyk.splitConfigFrom(simple_config)
+    return splitConfigFrom(simple_config)
 
 if __name__ == '__main__':
     (generatedTop, initSubst) = get_init_config()

--- a/wasm-with-k-term.md
+++ b/wasm-with-k-term.md
@@ -14,5 +14,6 @@ endmodule
 module WASM-WITH-K-TERM
     imports WASM-TEST
     imports K-TERM
+    imports K-IO
 endmodule
 ```

--- a/wasm-with-k-term.md
+++ b/wasm-with-k-term.md
@@ -1,0 +1,18 @@
+KWasm with K-TERM
+=================
+
+**TODO**: This module is a HACK to get unparsing to work correctly.
+
+```k
+requires "test.k"
+
+module WASM-WITH-K-TERM-SYNTAX
+    imports WASM-WITH-K-TERM
+    imports WASM-TEST-SYNTAX
+endmodule
+
+module WASM-WITH-K-TERM
+    imports WASM-TEST
+    imports K-TERM
+endmodule
+```


### PR DESCRIPTION
-   Updates submodule to have `--coverage` support.
-   Adds in `WASM-WITH-K-TERM` hackish module to avoid unresolved issues with unparsing, and to import the K-IO module for using `--coverage`.
-   Attempts to add remaining unparsers needed for polkadot code.
-   Adds `build-coverage-llvm` target for building the LLVM backend in coverage mode.