### PR TITLE
Extract rule traces from simple test-suite

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -75,7 +75,7 @@ pipeline {
           options { timeout(time: 20, unit: 'MINUTES') }
           steps {
             sh '''
-              make test-fuse-rules -j6
+              make test-fuse-rules
             '''
           }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -55,6 +55,7 @@ pipeline {
     stage('Test') {
       parallel {
         stage('Can Build Specs') {
+          options { timeout(time: 1, unit: 'MINUTES') }
           steps {
             sh '''
               make test-can-build-specs -j6
@@ -62,6 +63,7 @@ pipeline {
           }
         }
         stage('Python Config') {
+          options { timeout(time: 1, unit: 'MINUTES') }
           steps {
             sh '''
               make test-python-config

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -70,6 +70,14 @@ pipeline {
             '''
           }
         }
+        stage('Fuse Rules Simple') {
+          options { timeout(time: 20, unit: 'MINUTES') }
+          steps {
+            sh '''
+              make test-fuse-rules
+            '''
+          }
+        }
       }
     }
   }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -75,7 +75,7 @@ pipeline {
           options { timeout(time: 20, unit: 'MINUTES') }
           steps {
             sh '''
-              make test-fuse-rules
+              make test-fuse-rules -j6
             '''
           }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -39,7 +39,8 @@ pipeline {
         stage('KWasm') {
           steps {
             sh '''
-              make build -j4
+              make build SUBDEFN=kwasm                                 -j4
+              make build SUBDEFN=coverage KOMPILE_OPTIONS='--coverage' -j4
             '''
           }
         }

--- a/Makefile
+++ b/Makefile
@@ -125,14 +125,14 @@ $(POLKADOT_RUNTIME_WASM):
 #       Would be better without the `rm -rf ...`, and with these:
 #           $(KPOL) run --backend $(CONCRETE_BACKEND) $(SIMPLE_TESTS)/$*.wast --coverage-file $(SIMPLE_TESTS)/$*.wast.$(CONCRETE_BACKEND)-coverage
 #           ./translateCoverage.py _ _ $(SIMPLE_TESTS)/$*.wast.$(SYMBOLIC_BACKEND)-coverage
-%.wast.fuse-rules: build-coverage-llvm build-coverage-haskell
-	rm -rf $(DEFN_DIR)/kwasm/$(CONCRETE_BACKEND)/$(MAIN_DEFN_FILE)-kompiled/*_coverage.txt
-	$(KPOL) run --backend $(CONCRETE_BACKEND) $*.wast
-	./translateCoverage.py $(DEFN_DIR)/kwasm/$(CONCRETE_BACKEND)/$(MAIN_DEFN_FILE)-kompiled/allRules.txt   \
-	                       $(DEFN_DIR)/kwasm/$(SYMBOLIC_BACKEND)/$(MAIN_DEFN_FILE)-kompiled/allRules.txt   \
-	                       $(DEFN_DIR)/kwasm/$(CONCRETE_BACKEND)/$(MAIN_DEFN_FILE)-kompiled/*_coverage.txt \
+%.wast.fuse-rules:
+	rm -rf $(DEFN_DIR)/coverage/$(CONCRETE_BACKEND)/$(MAIN_DEFN_FILE)-kompiled/*_coverage.txt
+	SUBDEFN=coverage $(KPOL) run --backend $(CONCRETE_BACKEND) $*.wast
+	./translateCoverage.py $(DEFN_DIR)/coverage/$(CONCRETE_BACKEND)/$(MAIN_DEFN_FILE)-kompiled/allRules.txt   \
+	                       $(DEFN_DIR)/coverage/$(SYMBOLIC_BACKEND)/$(MAIN_DEFN_FILE)-kompiled/allRules.txt   \
+	                       $(DEFN_DIR)/coverage/$(CONCRETE_BACKEND)/$(MAIN_DEFN_FILE)-kompiled/*_coverage.txt \
 	                     > $*.wast.coverage-$(SYMBOLIC_BACKEND)
-	# $(KPOL) run --backend $(SYMBOLIC_BACKEND) $*.wast.coverage-$(SYMBOLIC_BACKEND) --rule-sequence
+	# SUBDEFN=coverage $(KPOL) run --backend $(SYMBOLIC_BACKEND) $*.wast.coverage-$(SYMBOLIC_BACKEND) --rule-sequence
 
 # Specification Build
 # -------------------

--- a/Makefile
+++ b/Makefile
@@ -164,8 +164,11 @@ $(SPECS_DIR)/%-spec.k.can-build: $(SPECS_DIR)/%-spec.k
 	    $<
 	rm -rf $*-kompiled
 
-simple_tests     := $(wildcard $(KWASM_SUBMODULE)/tests/simple/*.wast)
-bad_simple_tests := $(KWASM_SUBMODULE)/tests/simple/arithmetic.wast
+all_simple_tests := $(wildcard $(KWASM_SUBMODULE)/tests/simple/*.wast)
+bad_simple_tests := $(KWASM_SUBMODULE)/tests/simple/arithmetic.wast \
+                    $(KWASM_SUBMODULE)/tests/simple/comparison.wast \
+                    $(KWASM_SUBMODULE)/tests/simple/memory.wast
+simple_tests     := $(filter-out $(bad_simple_tests), $(all_simple_tests))
 
 test-fuse-rules: $(simple_tests:=.fuse-rules)
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
 
 .PHONY: clean distclean deps deps-polkadot              \
-        build build-coverage-llvm specs                 \
+        build                                           \
         polkadot-runtime-source polkadot-runtime-loaded \
+        specs                                           \
         test test-can-build-specs test-python-config
 
 # Settings
@@ -33,6 +34,8 @@ TANGLER                 := $(PANDOC_TANGLE_SUBMODULE)/tangle.lua
 LUA_PATH                := $(PANDOC_TANGLE_SUBMODULE)/?.lua;;
 export TANGLER
 export LUA_PATH
+
+KPOL := ./kpol
 
 clean:
 	rm -rf $(DEFN_DIR) tests/*.out
@@ -99,10 +102,10 @@ polkadot-runtime-source: src/polkadot-runtime.wat
 polkadot-runtime-loaded: src/polkadot-runtime.loaded.json
 
 src/polkadot-runtime.loaded.json: src/polkadot-runtime.wat.json
-	./kpol run --backend $(CONCRETE_BACKEND) $< --parser cat --output json > $@
+	$(KPOL) run --backend $(CONCRETE_BACKEND) $< --parser cat --output json > $@
 
 src/polkadot-runtime.wat.json: src/polkadot-runtime.env.wat src/polkadot-runtime.wat
-	cat $^ | ./kpol kast --backend $(CONCRETE_BACKEND) - json > $@
+	cat $^ | $(KPOL) kast --backend $(CONCRETE_BACKEND) - json > $@
 
 src/polkadot-runtime.wat: $(POLKADOT_RUNTIME_WASM)
 	wasm2wat $< > $@
@@ -134,7 +137,6 @@ $(SPECS_DIR)/%-spec.k: %.md
 # Testing
 # -------
 
-TEST  := ./kpol
 CHECK := git --no-pager diff --no-index --ignore-all-space
 
 test: test-can-build-specs

--- a/Makefile
+++ b/Makefile
@@ -61,21 +61,25 @@ deps-polkadot:
 
 KOMPILE_OPTIONS :=
 
+MAIN_MODULE        := WASM-WITH-K-TERM
+MAIN_SYNTAX_MODULE := WASM-WITH-K-TERM-SYNTAX
+MAIN_DEFN_FILE     := wasm-with-k-term
+
 build: build-kwasm-haskell build-kwasm-llvm build-coverage-llvm
 
 # Regular Semantics Build
 # -----------------------
 
-build-kwasm-%: $(DEFN_DIR)/kwasm/%/wasm-with-k-term.k
-	$(KWASM_MAKE) build-$*                         \
-	    DEFN_DIR=../../$(DEFN_DIR)/kwasm           \
-	    MAIN_MODULE=WASM-WITH-K-TERM               \
-	    MAIN_SYNTAX_MODULE=WASM-WITH-K-TERM-SYNTAX \
-	    MAIN_DEFN_FILE=wasm-with-k-term            \
+build-kwasm-%: $(DEFN_DIR)/kwasm/%/$(MAIN_DEFN_FILE).k
+	$(KWASM_MAKE) build-$*                       \
+	    DEFN_DIR=../../$(DEFN_DIR)/kwasm         \
+	    MAIN_MODULE=$(MAIN_MODULE)               \
+	    MAIN_SYNTAX_MODULE=$(MAIN_SYNTAX_MODULE) \
+	    MAIN_DEFN_FILE=$(MAIN_DEFN_FILE)         \
 	    KOMPILE_OPTIONS=$(KOMPILE_OPTIONS)
 
-.SECONDARY: $(DEFN_DIR)/kwasm/llvm/wasm-with-k-term.k    \
-            $(DEFN_DIR)/kwasm/haskell/wasm-with-k-term.k
+.SECONDARY: $(DEFN_DIR)/kwasm/llvm/$(MAIN_DEFN_FILE).k    \
+            $(DEFN_DIR)/kwasm/haskell/$(MAIN_DEFN_FILE).k
 
 $(DEFN_DIR)/kwasm/llvm/%.k: %.md $(TANGLER)
 	@mkdir -p $(dir $@)

--- a/Makefile
+++ b/Makefile
@@ -164,7 +164,8 @@ $(SPECS_DIR)/%-spec.k.can-build: $(SPECS_DIR)/%-spec.k
 	    $<
 	rm -rf $*-kompiled
 
-simple_tests := $(wildcard $(KWASM_SUBMODULE)/tests/simple/*.wast)
+simple_tests     := $(wildcard $(KWASM_SUBMODULE)/tests/simple/*.wast)
+bad_simple_tests := $(KWASM_SUBMODULE)/tests/simple/arithmetic.wast
 
 test-fuse-rules: $(simple_tests:=.fuse-rules)
 

--- a/Makefile
+++ b/Makefile
@@ -125,13 +125,15 @@ $(POLKADOT_RUNTIME_WASM):
 #       Would be better without the `rm -rf ...`, and with these:
 #           $(KPOL) run --backend $(CONCRETE_BACKEND) $(SIMPLE_TESTS)/$*.wast --coverage-file $(SIMPLE_TESTS)/$*.wast.$(CONCRETE_BACKEND)-coverage
 #           ./translateCoverage.py _ _ $(SIMPLE_TESTS)/$*.wast.$(SYMBOLIC_BACKEND)-coverage
-%.wast.fuse-rules:
+$(KWASM_SUBMODULE)/tests/simple/%.wast.coverage-$(CONCRETE_BACKEND): $(KWASM_SUBMODULE)/tests/simple/%.wast
 	rm -rf $(DEFN_DIR)/coverage/$(CONCRETE_BACKEND)/$(MAIN_DEFN_FILE)-kompiled/*_coverage.txt
-	SUBDEFN=coverage $(KPOL) run --backend $(CONCRETE_BACKEND) $*.wast
-	./translateCoverage.py $(DEFN_DIR)/coverage/$(CONCRETE_BACKEND)/$(MAIN_DEFN_FILE)-kompiled/allRules.txt   \
-	                       $(DEFN_DIR)/coverage/$(SYMBOLIC_BACKEND)/$(MAIN_DEFN_FILE)-kompiled/allRules.txt   \
-	                       $(DEFN_DIR)/coverage/$(CONCRETE_BACKEND)/$(MAIN_DEFN_FILE)-kompiled/*_coverage.txt \
-	                     > $*.wast.coverage-$(SYMBOLIC_BACKEND)
+	SUBDEFN=coverage $(KPOL) run --backend $(CONCRETE_BACKEND) $<
+	mv $(DEFN_DIR)/coverage/$(CONCRETE_BACKEND)/$(MAIN_DEFN_FILE)-kompiled/*_coverage.txt $@
+
+$(KWASM_SUBMODULE)/tests/simple/%.wast.coverage-$(SYMBOLIC_BACKEND): $(KWASM_SUBMODULE)/tests/simple/%.wast.coverage-$(CONCRETE_BACKEND)
+	./translateCoverage.py $(DEFN_DIR)/coverage/$(CONCRETE_BACKEND)/$(MAIN_DEFN_FILE)-kompiled \
+	                       $(DEFN_DIR)/coverage/$(SYMBOLIC_BACKEND)/$(MAIN_DEFN_FILE)-kompiled \
+	                       $< > $@
 	# SUBDEFN=coverage $(KPOL) run --backend $(SYMBOLIC_BACKEND) $*.wast.coverage-$(SYMBOLIC_BACKEND) --rule-sequence
 
 # Specification Build
@@ -170,7 +172,7 @@ bad_simple_tests := $(KWASM_SUBMODULE)/tests/simple/arithmetic.wast \
                     $(KWASM_SUBMODULE)/tests/simple/memory.wast
 simple_tests     := $(filter-out $(bad_simple_tests), $(all_simple_tests))
 
-test-fuse-rules: $(simple_tests:=.fuse-rules)
+test-fuse-rules: $(KWASM_SUBMODULE)/tests/simple/branching.wast.coverage-$(SYMBOLIC_BACKEND)
 
 # Python Configuration Build
 # --------------------------

--- a/kpol
+++ b/kpol
@@ -2,5 +2,5 @@
 
 export K_OPTS=-Xmx24G
 export KWASM_DIR=$(pwd)
-export KWASM_DEFN_DIR=$(pwd)/.build/defn/kwasm
+export KWASM_DEFN_DIR=$(pwd)/.build/defn/${SUBDEFN:-kwasm}
 deps/wasm-semantics/kwasm "$@"

--- a/translateCoverage.py
+++ b/translateCoverage.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+
+import sys
+
+def _fatal(msg, exit_code = 1):
+    sys.stderr.write('!!! ' + msg + '\n')
+    sys.stderr.flush()
+    sys.exit(exit_code)
+
+src_all_rules_file = sys.argv[1]
+dst_all_rules_file = sys.argv[2]
+src_rules_file     = sys.argv[3]
+
+src_rule_map = {}
+with open(src_all_rules_file, 'r') as src_all_rules:
+    for line in src_all_rules:
+        [ src_rule_hash, src_rule_loc ] = line.split(' ')
+        src_rule_loc = src_rule_loc.split('/')[-1]
+        src_rule_map[src_rule_hash.strip()] = src_rule_loc.strip()
+
+dst_rule_map = {}
+with open(dst_all_rules_file, 'r') as dst_all_rules:
+    for line in dst_all_rules:
+        [ dst_rule_hash, dst_rule_loc ] = line.split(' ')
+        dst_rule_loc = dst_rule_loc.split('/')[-1]
+        dst_rule_map[dst_rule_loc.strip()] = dst_rule_hash.strip()
+
+src_rule_list = []
+with open(src_rules_file, 'r') as src_rules:
+    src_rule_list = [ rule_hash.strip() for rule_hash in src_rules ]
+
+dst_rule_list = []
+for src_rule in src_rule_list:
+    if src_rule in src_rule_map:
+        src_rule_loc = src_rule_map[src_rule]
+        if src_rule_loc in dst_rule_map:
+            dst_rule = dst_rule_map[src_rule_loc]
+            dst_rule_list.append(dst_rule)
+        else:
+            _fatal('COULD NOT FIND RULE LOCATION IN dst_rule_map: ' + src_rule_loc)
+    else:
+        _fatal('COULD NOT FIND RULE IN src_rule_map: ' + src_rule)
+
+for dst_rule_hash in dst_rule_list:
+    sys.stdout.write(dst_rule_hash + '\n')
+sys.stdout.flush()

--- a/translateCoverage.py
+++ b/translateCoverage.py
@@ -7,19 +7,19 @@ def _fatal(msg, exit_code = 1):
     sys.stderr.flush()
     sys.exit(exit_code)
 
-src_all_rules_file = sys.argv[1]
-dst_all_rules_file = sys.argv[2]
-src_rules_file     = sys.argv[3]
+src_kompiled_dir = sys.argv[1]
+dst_kompiled_dir = sys.argv[2]
+src_rules_file   = sys.argv[3]
 
 src_rule_map = {}
-with open(src_all_rules_file, 'r') as src_all_rules:
+with open(src_kompiled_dir + '/allRules.txt', 'r') as src_all_rules:
     for line in src_all_rules:
         [ src_rule_hash, src_rule_loc ] = line.split(' ')
         src_rule_loc = src_rule_loc.split('/')[-1]
         src_rule_map[src_rule_hash.strip()] = src_rule_loc.strip()
 
 dst_rule_map = {}
-with open(dst_all_rules_file, 'r') as dst_all_rules:
+with open(dst_kompiled_dir + '/allRules.txt', 'r') as dst_all_rules:
     for line in dst_all_rules:
         [ dst_rule_hash, dst_rule_loc ] = line.split(' ')
         dst_rule_loc = dst_rule_loc.split('/')[-1]


### PR DESCRIPTION
Fixes: #30 

After doing:

1.    `make deps`: Build K and Substrate.
2.    `make build SUBDEFN=coverage -j2`
3.    `make test-fuse-rules`

The files `deps/wasm-semantics/tests/simple/*.wast.coverage-haskell` will contain the rule hashes which uniquely identify the rules in file `.build/defn/coverage/haskell/wasm-with-k-term-kompiled/definition.kore`.

How this works is that (2) builds the semantics in instrumented form so that each rule is augmented with an attribute `UNIQUE_ID` which uniquely identifies that rule. Then when we run (3), the LLVM backend is run on each `simple` program, dumping the rule traces (in the form of a sequence of the unique identifiers) to a file. The sequence of llvm-backend unique identifier is converted to the haskell-backend variants by the `translateCoverage.py` script (since the two backends don't get the same unique identifiers). The translated sequence is dumped into the `*.coverage-haskell` file.

Ideally, we'd like to be able to say:

```
SUBDEFN=coverage ./kpol run --backend haskell deps/wasm-semantics/tests/simple/*.wast.coverage-haskell --fuse-rules
```

which will invoke the haskell backend on the rule-list file (using the definition augmented with the unique rule IDs), and instead of executing it, the haskell backend will return the fused rules.