### PR TITLE
Set balance rules preparation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -138,7 +138,7 @@ $(KWASM_SUBMODULE)/tests/simple/%.wast.coverage-$(SYMBOLIC_BACKEND): $(KWASM_SUB
 # Specification Build
 # -------------------
 
-SPEC_NAMES := set-free-balance
+SPEC_NAMES := set-balance
 
 SPECS_DIR := $(BUILD_DIR)/specs
 ALL_SPECS := $(patsubst %, $(SPECS_DIR)/%-spec.k, $(SPEC_NAMES))

--- a/set-balance.md
+++ b/set-balance.md
@@ -1,42 +1,16 @@
-`set_free_balance` spec
+`set_balance` spec
 =======================
-
-The Rust code is here:
-
-```
-/// Set the free balance of an account to some new value. Will enforce `ExistentialDeposit`
-/// law, annulling the account as needed.
-///
-/// Doesn't do any preparatory work for creating a new account, so should only be used when it
-/// is known that the account already exists.
-///
-/// NOTE: LOW-LEVEL: This will not attempt to maintain total issuance. It is expected that
-/// the caller will do this.
-fn set_free_balance(who: &T::AccountId, balance: T::Balance) -> UpdateBalanceOutcome {
-  // Commented out for now - but consider it instructive.
-  // assert!(!Self::total_balance(who).is_zero());
-  // assert!(Self::free_balance(who) > T::ExistentialDeposit::get());
-  if balance < T::ExistentialDeposit::get() {
-    <FreeBalance<T, I>>::insert(who, balance);
-    Self::on_free_too_low(who);
-    UpdateBalanceOutcome::AccountKilled
-  } else {
-    <FreeBalance<T, I>>::insert(who, balance);
-    UpdateBalanceOutcome::Updated
-  }
-}
-```
 
 State Model
 -----------
 
 ```k
-module SET-FREE-BALANCE-SPEC
+module SET-BALANCE-SPEC
     imports INT
     imports LIST
 
     configuration
-      <set-free-balance>
+      <set-balance>
         <k> $ACTION:Action </k>
         <events> .List </events>
         <existentialDeposit> 0 </existentialDeposit>
@@ -47,7 +21,7 @@ module SET-FREE-BALANCE-SPEC
             <nonce> .Nonce </nonce>
           </account>
         </accounts>
-      </set-free-balance>
+      </set-balance>
 ```
 
 Data
@@ -144,6 +118,57 @@ A `Result` is considered an `Action`.
          </accounts>
       requires BALANCE <Int EXISTENTIAL_DEPOSIT
 ```
+
+
+### `set_reserved_balance`
+
+-   Updates an accounts balance if the new balance is above the existential threshold.
+-   Kills the account if the balance goes below the existential threshold and the free balance is non-zero.
+-   Reaps the account if the balance goes below the existential threshold and the free balance is zero.
+
+```k
+    syntax Action ::= "set_reserved_balance" "(" AccountId "," Int ")"
+ // --------------------------------------------------------------
+    rule [reserved-account-updated]:
+         <k> set_reserved_balance(WHO, BALANCE) => Updated </k>
+         <existentialDeposit> EXISTENTIAL_DEPOSIT </existentialDeposit>
+         <account>
+           <accountID> WHO </accountID>
+           <balance> _ | (_ => BALANCE) </balance>
+           ...
+         </account>
+      requires EXISTENTIAL_DEPOSIT <=Int BALANCE
+
+    rule [reserved-account-killed]:
+         <k> set_reserved_balance(WHO, BALANCE) => AccountKilled </k>
+         <events> ... (.List => ListItem(DustEvent(RESERVED_BALANCE))) </events>
+         <existentialDeposit> EXISTENTIAL_DEPOSIT </existentialDeposit>
+         <account>
+           <accountID> WHO </accountID>
+           <nonce> _ => .Nonce </nonce>
+           <balance> FREE_BALANCE | (RESERVED_BALANCE => 0) </balance>
+           ...
+         </account>
+      requires BALANCE <Int EXISTENTIAL_DEPOSIT
+       andBool 0 <Int FREE_BALANCE
+
+    rule [reserved-account-reaped]:
+         <k> set_reserved_balance(WHO, BALANCE) => AccountKilled </k>
+         <events> ... (.List => ListItem(DustEvent(RESERVED_BALANCE))) </events>
+         <existentialDeposit> EXISTENTIAL_DEPOSIT </existentialDeposit>
+         <accounts>
+           ( <account>
+               <accountID> WHO </accountID>
+               <balance> 0 | RESERVED_BALANCE </balance>
+               ...
+             </account>
+          => .Bag
+           )
+           ...
+         </accounts>
+      requires BALANCE <Int EXISTENTIAL_DEPOSIT
+```
+
 
 ```k
 endmodule

--- a/set-balance.md
+++ b/set-balance.md
@@ -1,5 +1,5 @@
 `set_balance` spec
-=======================
+==================
 
 State Model
 -----------
@@ -119,7 +119,6 @@ A `Result` is considered an `Action`.
       requires BALANCE <Int EXISTENTIAL_DEPOSIT
 ```
 
-
 ### `set_reserved_balance`
 
 -   Updates an accounts balance if the new balance is above the existential threshold.
@@ -168,7 +167,6 @@ A `Result` is considered an `Action`.
          </accounts>
       requires BALANCE <Int EXISTENTIAL_DEPOSIT
 ```
-
 
 ```k
 endmodule


### PR DESCRIPTION
Changes made during pair programing on the 30/10.

- Renaming set-free-balance to set-balance.
- Adding similar rules for set-reserved-balance as for set-free-balance.