### PR TITLE
Harness for writing proofs about `set-balance`

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -64,11 +64,11 @@ pipeline {
     stage('Test') {
       when { changeRequest() }
       parallel {
-        stage('Can Build Specs') {
-          options { timeout(time: 1, unit: 'MINUTES') }
+        stage('Prove High Level Specs') {
+          options { timeout(time: 4, unit: 'MINUTES') }
           steps {
             sh '''
-              make test-can-build-specs -j6
+              make prove-specs -j6
             '''
           }
         }

--- a/Makefile
+++ b/Makefile
@@ -161,7 +161,7 @@ $(SPECS_DIR)/%-kompiled/definition.kore: $(SPECS_DIR)/%.k
 	    $<
 
 $(SPECS_DIR)/%-spec.k.prove: $(SPECS_DIR)/%-spec.k $(SPECS_DIR)/%-kompiled/definition.kore
-	kprove --directory $(SPECS_DIR) $<
+	kprove --directory $(SPECS_DIR) $< --def-module VERIFICATION
 
 # Testing
 # -------

--- a/Makefile
+++ b/Makefile
@@ -168,7 +168,7 @@ $(SPECS_DIR)/%-spec.k.prove: $(SPECS_DIR)/%-spec.k $(SPECS_DIR)/%-kompiled/defin
 
 CHECK := git --no-pager diff --no-index --ignore-all-space
 
-test: test-fuse-rules prove-specs
+test: test-fuse-rules prove-specs test-python-config
 
 all_simple_tests := $(wildcard $(KWASM_SUBMODULE)/tests/simple/*.wast)
 bad_simple_tests := $(KWASM_SUBMODULE)/tests/simple/arithmetic.wast     \

--- a/set-balance-spec.md
+++ b/set-balance-spec.md
@@ -1,0 +1,19 @@
+Balances Module Specifications
+==============================
+
+```k
+requires "set-balance.k"
+
+module VERIFICATION
+    imports SET-BALANCE
+
+    syntax EntryAction ::= foo ( Int ) | "bar"
+    rule <k> foo (X) => bar ... </k> requires X <Int 3
+endmodule
+
+module SET-BALANCE-SPEC
+    imports VERIFICATION
+
+    rule <k> foo(2) => bar ... </k>
+endmodule
+```

--- a/set-balance.md
+++ b/set-balance.md
@@ -5,7 +5,7 @@ State Model
 -----------
 
 ```k
-module SET-BALANCE-SPEC
+module SET-BALANCE
     imports INT
     imports DOMAINS
     imports COLLECTIONS


### PR DESCRIPTION
You can run `make prove-specs` to both (1) build the specification definition, and (2) run the proofs associated with that definition.

Currently only a single dummy placeholder proof is added, for demonstration.