### PR TITLE
Correct functional attributes, default account creation

### DIFF
--- a/set-balance.md
+++ b/set-balance.md
@@ -365,12 +365,12 @@ Helpers for calling `set_free_balance` and `set_reserved_balance`.
     rule [balance-set-free]:
          <k> set_balance_free(WHO, FREE_BALANCE') => set_free_balance(WHO, FREE_BALANCE') ... </k>
          <totalIssuance> ISSUANCE => ISSUANCE +Int (FREE_BALANCE' -Int free_balance(WHO)) </totalIssuance>
-      requires #inWidth(64, ISSUANCE +Int (FREE_BALANCE' -Int free_balance(WHO)))
+      requires #inWidth(96, ISSUANCE +Int (FREE_BALANCE' -Int free_balance(WHO)))
 
     rule [balance-set-reserved]:
          <k> set_balance_reserved(WHO, RESERVED_BALANCE') => set_reserved_balance(WHO, RESERVED_BALANCE') ... </k>
          <totalIssuance> ISSUANCE => ISSUANCE +Int (RESERVED_BALANCE' -Int reserved_balance(WHO)) </totalIssuance>
-      requires #inWidth(64, ISSUANCE +Int (RESERVED_BALANCE' -Int reserved_balance(WHO)))
+      requires #inWidth(96, ISSUANCE +Int (RESERVED_BALANCE' -Int reserved_balance(WHO)))
 ```
 
 ### `transfer_raw`

--- a/set-balance.md
+++ b/set-balance.md
@@ -491,6 +491,7 @@ Withdraw funds from an account.
     rule [withdraw]: // K really needs where clauses
          <k> withdraw(WHO, AMOUNT, REASON, EXISTENCE_REQUIREMENT)
           => withdrawInner(WHO, AMOUNT, AMOUNT -Int free_balance(WHO), REASON, EXISTENCE_REQUIREMENT)
+         ...
          </k>
 
     syntax Action ::= withdrawInner(AccountId, Int, Int, WithdrawReason, ExistenceRequirement)


### PR DESCRIPTION
Fixes: #60 

Adds `account_exists` and `create_account` primitives which other parts of the spec can use.

Also corrects some `functional` attribute rules to make sure they are total functions.