### PR TITLE
Update link of Polkadot Spec PDF

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Polkadot Module Verification
 
 -   Polkadot Runtime Environment (PRE): <https://wiki.polkadot.network/en/latest/polkadot/learn/PRE/>
 -   Balances module: <https://github.com/paritytech/substrate/blob/master/srml/balances/src/lib.rs>
--   Polkadot Spec: <https://github.com/w3f/polkadot-re-spec/blob/master/polkadot_re_spec.pdf>
+-   Polkadot Spec: <https://github.com/w3f/polkadot-spec/blob/master/runtime-environment-spec/polkadot_re_spec.pdf>
     See "Runtime Environment API" for external function specs (eg. `ext_malloc` and `ext_blake`).
 
 ### Building/Installation/Setup


### PR DESCRIPTION
The current link to the PDF file points to the deprecated repository.