### PR TITLE
Search updates

### DIFF
--- a/pykWasm.py
+++ b/pykWasm.py
@@ -88,7 +88,11 @@ def mergeRules(definition_dir, main_defn_file, main_module, subsequence, symbolT
         with tempfile.NamedTemporaryFile(mode = 'w') as tempf:
             tempf.write(stdout)
             tempf.flush()
-            (_, stdout, stderr) = pyk.kast(definition_dir, tempf.name, kastArgs = ['--input', 'kore', '--output', 'json'])
+            (rc, stdout, stderr) = pyk.kast(definition_dir, tempf.name, kastArgs = ['--input', 'kore', '--output', 'json'])
+            if rc != 0:
+                print(stderr)
+                _warning('Cannot merge rules!')
+                return None
             merged_rule = json.loads(stdout)['term']
             (lhs_term, lhs_constraint) = extractTermAndConstraint(merged_rule['lhs'])
             (rhs_term, rhs_constraint) = extractTermAndConstraint(merged_rule['rhs'])

--- a/pykWasm.py
+++ b/pykWasm.py
@@ -83,13 +83,13 @@ def mergeRulesKoreExec(definition_dir, ruleList, kArgs = [], teeOutput = True, k
         return _runK2('kore-exec', definition_dir, kArgs = ['--merge-rules', tempf.name] + kArgs, teeOutput = teeOutput, kRelease = kRelease)
 
 def mergeRules(definition_dir, main_defn_file, main_module, subsequence, symbolTable = None, definition = None):
-    (rc, stdout, stderr) = mergeRulesKoreExec(definition_dir + '/' + main_defn_file + '-kompiled/definition.kore', subsequence, kArgs = ['--module', main_module], symbolTable = symbolTable, definition = definition)
-    if rc == 0:
+    (returnCode, stdout, stderr) = mergeRulesKoreExec(definition_dir + '/' + main_defn_file + '-kompiled/definition.kore', subsequence, kArgs = ['--module', main_module], symbolTable = symbolTable, definition = definition)
+    if returnCode == 0:
         with tempfile.NamedTemporaryFile(mode = 'w') as tempf:
             tempf.write(stdout)
             tempf.flush()
-            (rc, stdout, stderr) = pyk.kast(definition_dir, tempf.name, kastArgs = ['--input', 'kore', '--output', 'json'])
-            if rc != 0:
+            (returnCode, stdout, stderr) = pyk.kast(definition_dir, tempf.name, kastArgs = ['--input', 'kore', '--output', 'json'])
+            if returnCode != 0:
                 print(stderr)
                 _warning('Cannot merge rules!')
                 return None

--- a/search.py
+++ b/search.py
@@ -131,7 +131,7 @@ if args['command'] == 'profile':
         print('\n'.join(ruleSeq))
         print()
         sys.stdout.flush()
-        mergedRules = tryMergeRules(WASM_definition_haskell_no_coverage_dir, WASM_definition_main_file, WASM_definition_main_module, [ruleSeq], timeout = mergeTimeout)
+        mergedRules = tryMergeRules(WASM_definition_haskell_no_coverage_dir, WASM_definition_main_file, WASM_definition_main_module, [ruleSeq])
         end_time = time.time()
         if len(mergedRules) > 0:
             lastSucceeded = True

--- a/search.py
+++ b/search.py
@@ -120,6 +120,8 @@ if args['command'] == 'profile':
                 ruleMerges.append(ruleSeq[i:i + mergeWidth])
     mergeStats = []
     mergeFails = []
+    lastSucceeded = True
+    badRules = []
     for (i, ruleSeq) in enumerate(ruleMerges):
         start_time = time.time()
         print()
@@ -127,15 +129,19 @@ if args['command'] == 'profile':
         print('\n'.join(ruleSeq))
         print()
         sys.stdout.flush()
-        mergedRules = tryMergeRules(WASM_definition_haskell_no_coverage_dir, WASM_definition_main_file, WASM_definition_main_module, [ruleSeq])
+        mergedRules = tryMergeRules(WASM_definition_haskell_no_coverage_dir, WASM_definition_main_file, WASM_definition_main_module, [ruleSeq], timeout = mergeTimeout)
         end_time = time.time()
         if len(mergedRules) > 0:
+            lastSucceeded = True
             print()
             print('SUCCESS')
             delta_time = end_time - start_time
             print('Time: ' + str(delta_time))
             mergeStats.append((delta_time, ruleSeq, mergedRules))
         else:
+            if lastSucceeded:
+                badRules.append(ruleSeq[-1])
+            lastSucceeded = False
             print()
             print('FAILURE')
             mergeFails.append(ruleSeq)
@@ -171,6 +177,12 @@ if args['command'] == 'profile':
         print('### Rules')
         print()
         print('\n'.join(s))
+    if len(badRules) > 0:
+        print()
+        print('Potential Bad Rules')
+        print('-------------------')
+        print()
+        print('\n'.join(set(badRules)))
     print()
     print('Stats')
     print('-----')

--- a/search.py
+++ b/search.py
@@ -93,6 +93,8 @@ for i in range(numExec):
 
 ruleSeqs = [ ruleSeq.split('|') for ruleSeq in ruleSeqs ]
 print('Found ' + str(len(ruleSeqs)) + ' unique executions.')
+for rs in ruleSeqs:
+    print('    Execution length: ' + str(len(rs)))
 print()
 sys.stdout.flush()
 


### PR DESCRIPTION
-   Output length of each execution for quickly seeing whether it was a trivial non-execution or actually a good trace.
-   More graceful failure when rule merging fails.
-   ~Add timeout option to various function calls (note this won't actually do anything until kframework/k#1342 gets merged).~ This will be added in a later PR.