### PR TITLE
Reset sources after running update job on CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,7 +15,7 @@ pipeline {
       parallel {
         stage('KWasm (normal)')   { steps { sh 'make build -j4'                } }
         stage('KWasm (coverage)') { steps { sh 'make build -j4 BUILD=coverage' } }
-        stage('Polkadot')         { steps { sh 'make polkadot-runtime-source'  } { sh 'git checkout src/' } }
+        stage('Polkadot')         { steps { sh 'make polkadot-runtime-source ; git checkout src/ ;' } }
       }
     }
     stage('Test') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,7 +15,7 @@ pipeline {
       parallel {
         stage('KWasm (normal)')   { steps { sh 'make build -j4'                } }
         stage('KWasm (coverage)') { steps { sh 'make build -j4 BUILD=coverage' } }
-        stage('Polkadot')         { steps { sh 'make polkadot-runtime-source'  } }
+        stage('Polkadot')         { steps { sh 'make polkadot-runtime-source'  } { sh 'git checkout src/' } }
       }
     }
     stage('Test') {


### PR DESCRIPTION
The update job is only to test that it works to build the sources. Currently, CI calls `make polkadot-runtime-sources` but not `make polkadot-runtime-loaded`. It doesn't call the latter because it's very expensive. Every run of these `make` jobs update the name of the functions in the source code. Since `search.py` grabs the name of the `set_free_balance` function from the `.wat` file but calls the code in the `.json` file, there is a mismatch, and the call fails.